### PR TITLE
Shutdown Face Predictor node when there is no model to train on.

### DIFF
--- a/src/vision/cmt_tracker/scripts/face_predictor.py
+++ b/src/vision/cmt_tracker/scripts/face_predictor.py
@@ -56,6 +56,9 @@ class face_predictor:
             query_only = rospy.get_param('query_only', True)
             if query_only:
                 print("Operating in Query Mode There is Model so No Queries would happen")
+                rospy.signal_shutdown("Query Mode; No Model Found. Shutting Down Node")
+        else:
+            print ("Classifier Found")
 
         self.state ={'query_save': '00', 'save_only': '01','query_only': '10', 'ignore': '11'}
         #format
@@ -105,7 +108,7 @@ class face_predictor:
             #print(self.cmt_tracker_instances)
             if self.cmt_tracker_instances[key]['state'] == self.state['query_save']:
                 self.queryAddResults(cv_image, tupl, key, self.confidence)
-                print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
+                # print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
 
 
             elif not query_only and (self.cmt_tracker_instances[key]['state'] == self.state['save_only'] or self.cmt_tracker_instances[key]['state'] == self.state['query_save']):
@@ -113,7 +116,7 @@ class face_predictor:
 
             elif self.cmt_tracker_instances[key]['state'] == self.state['query_only']:
                 self.queryAddResults(cv_image, tupl, key, self.confidence)
-                print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
+                # print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
                 if key not in self.google_query:
                     self.face_recognizer.temp_save_faces(cv_image, tupl, key)
                     self.google_query.append(key)
@@ -128,8 +131,8 @@ class face_predictor:
 
                 if self.cmt_tracker_instances[key]['state'] == self.state['query_save'] or self.cmt_tracker_instances[key]['state'] == self.state['query_only']:
                     max_index = max(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'], key=self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'].get)
-                    print("openface output results: ")
-                    print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
+                    # print("openface output results: ")
+                    # print(self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'])
                     if self.face_recognizer.face_results_aggregator[cmt.tracker_name.data]['results'][max_index] > self.num_positive:
                         try:
                             self.upt = rospy.ServiceProxy('recognition', TrackerNames)

--- a/src/vision/cmt_tracker/scripts/face_reinforcer.py
+++ b/src/vision/cmt_tracker/scripts/face_reinforcer.py
@@ -304,7 +304,7 @@ class face_reinforcer:
 
 
         self.persistance_face[:] = [get_element for get_element in self.persistance_face if not (self.trim(get_element[6],self.window_size))]
-        print(self.persistance_face)
+        # print(self.persistance_face)
 
         return not_covered_faces, overlaped_faces, not_good
     def determine(self, get_element,j):


### PR DESCRIPTION
Resolves #96. Now the Face Predictor Shuts down when there is no model found to query faces against. Shutting down currently is the only viable option as the node wouldn't do anything unless issue 144 in openface repo is resolved so that we can add faces to db during runtime. 
