### PR TITLE
Move google image scraper to not executing section.

### DIFF
--- a/src/vision/cmt_tracker/scripts/face_predictor.py
+++ b/src/vision/cmt_tracker/scripts/face_predictor.py
@@ -14,13 +14,14 @@ from cmt_tracker_msgs.cfg import RecognitionConfig
 from dynamic_reconfigure.server import Server
 
 from openface_wrapper import face_recognizer
-from image_scraper import image_scaper
+
 from pi_face_tracker.msg import FaceEvent
 class face_predictor:
     def __init__(self):
         rospy.init_node('face_recognizer', anonymous=True)
         self.image_scraper_enable = rospy.get_param('image_scraper')
         if self.image_scraper_enable != 0:
+            from image_scraper import image_scaper
             self.user_agents = rospy.get_param('user_agents')
             self.image_scraper = image_scaper(self.user_agents)
 


### PR DESCRIPTION
Workaround for #132 till time comes to where the google image scrapper being built is functioning. @wenwei-dev I see you haven't used setup.py install in hrtool; Is such format feasible? 

```
wget ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz
tar -xf libxml2-2.9.2.tar.gz
cd libxml2-2.9.2/python
python setup.py install
```

I couldn't find package's that where recent (after 2.6.21) that have simple python package installation. 
