### PR TITLE
Enable and Disable the cmt tracker output from dynamic reconfigure.

### DIFF
--- a/src/vision/cmt_tracker/include/cmt_tracker_node.h
+++ b/src/vision/cmt_tracker/include/cmt_tracker_node.h
@@ -209,7 +209,7 @@ private:
 	double factor;
 	int delete_counter;
 	int downgrade;
-
+    bool enable_tracker;
 	//for setting the tracking to higher levels.
 	std::vector<cv::Rect> locations_of_trackers;
 

--- a/src/vision/cmt_tracker/src/cmt_tracker_node.cpp
+++ b/src/vision/cmt_tracker/src/cmt_tracker_node.cpp
@@ -174,6 +174,10 @@ This  function is a callback function that happens when an image update occurs.
 */
 void TrackerCMT::imageCb(const sensor_msgs::ImageConstPtr& msg,const sensor_msgs::CameraInfoConstPtr& camerainfo)
 {
+    if (!enable_tracker)
+    {
+    return;
+    }
 
   //std::cout<<"Enters imageCB"<<std::endl;
   //-//std::cout<<"Enters imageCB conversion"<<std::endl;
@@ -352,6 +356,7 @@ void TrackerCMT::callback(cmt_tracker_msgs::TrackerConfig &config, uint32_t leve
   factor = config.factor;
   //std::cout<<"config: "<<config.frame_counter;
   delete_counter = config.frame_counter;
+  enable_tracker = config.enable;
   //std::cout<<"Factor Updated to: "<<factor<<std::endl;
 }
 void TrackerCMT::list_of_faces_update(const cmt_tracker_msgs::Objects& faces_info)

--- a/src/vision/cmt_tracker_msgs/cfg/Tracker.cfg
+++ b/src/vision/cmt_tracker_msgs/cfg/Tracker.cfg
@@ -5,7 +5,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-
+gen.add("enable", bool_t, 0, "Enable CMT_Tracker", True )
 gen.add("factor", double_t, 0, "Scale between Current Active Point to Initial Active Point Before Tracker Lost",0.6, 0, 1)
 gen.add("frame_counter", int_t, 0, "Number of Frames before we discard the CMT tracker instance", 10, 1, 300)
 exit(gen.generate(PACKAGE, "cmt_tracker_msgs", "Tracker"))


### PR DESCRIPTION
@wenwei-dev This creates this issues; Say we have the rqt_tracker view; It would stop updating itself. That would distract the users;(ofcourse a person can start the information in headless mode) but we need to kill some nodes preferably so that all the relevant cmt_tracker_nodes work consistently when enabled again. For instance; we need to shut down cmt_tracker, face_reinforcer, rqt plugin and face detector for the cmt_tracker. We can use http://wiki.ros.org/roslaunch/API%20Usage to shut down relevant nodes. This also requires that i separate the different packages to work from different tools(cmt_tracker/pi_vision. I would do those this week; But first i have finish the refactoring of the CppMT and finish the RANSAC variant for scale and rotation estimation. Till then i guess we can quickly add enable to all the cmt dependent packages if this issue is critical. 
