### PR TITLE
Bug fix for bug #206

### DIFF
--- a/scripts/hrtool
+++ b/scripts/hrtool
@@ -305,6 +305,7 @@ install_test_deps() {
 install_vision_deps() {
     info "Installing vision dependencies"
     mkdir -p $VISION_TOOL_PREFIX
+    $SUDO apt-get ${APT_GET_OPTS} install libopencv-dev
     $SUDO apt-get ${APT_GET_OPTS} install ros-indigo-opencv-apps
 
     # Tkinter error other wise.

--- a/scripts/hrtool
+++ b/scripts/hrtool
@@ -383,23 +383,25 @@ install_vision_deps() {
     if [ ! -d $CPPMT_DIR ]; then
       info "Cloning CppMT"
       git clone https://github.com/hansonrobotics/CppMT.git $CPPMT_DIR
-      cd $CPPMT_DIR
-      git checkout wrapper
-      cmake .
-      make -j$(nproc)
     else
       warn "Skipping CppMT clone"
     fi
+    cd $CPPMT_DIR
+    git checkout wrapper
+    mkdir build
+    cd build
+    cmake ..
+    make -j$(nproc)
 
     if [ ! -d $EMOTIME_DIR ]; then
       info "Cloning emotime"
       git clone https://github.com/hansonrobotics/emotime.git $EMOTIME_DIR
-      cd $EMOTIME_DIR/build
-      cmake ..
-      make -j$(nproc)
     else
       warn "Skipping emotime clone"
     fi
+    cd $EMOTIME_DIR/build
+    cmake ..
+    make -j$(nproc)
     info "Installing vision dependencies is done"
 }
 


### PR DESCRIPTION
Any sort of install issues cause cppmt and emotime to not be built.
Fix this, so that repeated runs of `hrtool -i` will actually build
these deps.
