### PR TITLE
Latest version of relex build fails--not compatible with link grammer version installed with hrtool

### DIFF
--- a/scripts/hrtool
+++ b/scripts/hrtool
@@ -325,19 +325,19 @@ install_opencog_deps() {
 install_link_grammar() {
     info "Installing Link-Grammar"
 
-    MD5SUMS["link-grammar-5.3.13.tar.gz"]=d519ff9f404bbda5bfe229839272d91c
-    wget_cache $GITHUB_STORAGE_URL/link-grammar-5.3.13.tar.gz
+    MD5SUMS["link-grammar-5.3.15.tar.gz"]=446078337753bfb1d39f80281acee70d
+    wget_cache $GITHUB_STORAGE_URL/link-grammar-5.3.15.tar.gz
 
-    $SUDO rm -rf /tmp/link-grammar-5.3.13
-    tar -zxf ${HR_CACHE}/link-grammar-5.3.13.tar.gz -C /tmp
-    mkdir -p /tmp/link-grammar-5.3.13/build
-    cd /tmp/link-grammar-5.3.13/build
+    $SUDO rm -rf /tmp/link-grammar-5.3.15
+    tar -zxf ${HR_CACHE}/link-grammar-5.3.15.tar.gz -C /tmp
+    mkdir -p /tmp/link-grammar-5.3.15/build
+    cd /tmp/link-grammar-5.3.15/build
     JAVA_HOME=/usr/lib/jvm/default-java
     ../configure
     make -j$(nproc)
     $SUDO make install
     $SUDO ldconfig
-    $SUDO rm -rf /tmp/link-grammar-5.3.13
+    $SUDO rm -rf /tmp/link-grammar-5.3.15
     cd $BASEDIR
     info "Installing Link-Grammar done"
 }
@@ -352,7 +352,9 @@ install_relex_deps() {
     )
     apt_get_install "${pkgs[@]}"
 
-    if [[ ! -e /usr/local/lib/liblink-grammar.so ]]; then
+    if [[ ! -e /usr/local/lib/liblink-grammar.so ||
+        ! $(readlink /usr/local/lib/liblink-grammar.so) = "liblink-grammar.so.5.3.15" ]];
+    then
         install_link_grammar
     fi
 


### PR DESCRIPTION
Using the latest from the opencog repos, that is, using "./hrtool -d"

With ./hrtool -B, Relex build fails:

build-project:
     [echo] relex: /home/eddie/hansonrobotics/opencog/relex/build.xml
    [javac] Compiling 9 source files to /home/eddie/hansonrobotics/opencog/relex/bin
    [javac] /home/eddie/hansonrobotics/opencog/relex/src/java/relex/Server.java:383: error: cannot find symbol
    [javac] 		LinkGrammar.doFinalize();
    [javac] 		           ^
    [javac]   symbol:   method doFinalize()
    [javac]   location: class LinkGrammar
    [javac] /home/eddie/hansonrobotics/opencog/relex/src/java/relex/parser/LocalLGParser.java:78: error: cannot find symbol
    [javac] 		LinkGrammar.doFinalize();
    [javac] 		           ^
    [javac]   symbol:   method doFinalize()
    [javac]   location: class LinkGrammar
    [javac] 2 errors

BUILD FAILED

According to opencog/relex#255#issuecomment-279496553 doFinalize() depends on link-grammer version 5.3.15. hrtool installs version 5.3.13. 

I attempted some code to resolve this by changing the version, as well as adding a test to update if the link-grammar lib is not the required version, but link-grammar-5.3.15.tar.gz would need to be added to $GITHUB_STORAGE_URL for this to work. And I'm not sure what I'm doing is the best approach for resolving the issue.
